### PR TITLE
Update projectsWithFinancials.js to remove Record Type

### DIFF
--- a/projectsWithFinancials.js
+++ b/projectsWithFinancials.js
@@ -1,7 +1,5 @@
 // Update project
 upsert('ampi__Project__c', 'Agresso_Unique_ID__c', fields(
-  // NOTE: Delete the following line to use default record type and stop inserts
-  relationship('RecordType', 'name', '4 - Project'),
   field('Name', dataValue('field1')), // Project Code
   field('Agresso_Unique_ID__c', dataValue('field1')), // Project Code
   field('Title__c', state => {


### PR DESCRIPTION
Removed line to update Record Type as this was creating unwanted updates. Updated Validation Rule in Salesforce to prevent the integration user from creating any new ampi__Project__c records as follows: 

AND(ISNEW(), 
Owner:User.Alias = "iuser" 
)